### PR TITLE
Handle input events

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/Dermah/pulsar-transmitter",
   "dependencies": {
-    "@dermah/pulsar-input-keyboard": "^0.1.0",
+    "@dermah/pulsar-input-keyboard": "^0.2.0",
     "express": "^4.13.4",
     "jade": "^1.11.0",
     "jsonfile": "^2.2.3",

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ var Transmitter = function (config) {
   router(config);
 
   var io = require('socket.io')(router.server);
-  // Socket.io connection handling 
+  // Socket.io connection handling
   io.on('connection', function(socket){
     console.log('PULSAR: client connected');
     socket.on('disconnect', function() {
@@ -13,7 +13,17 @@ var Transmitter = function (config) {
   });
 
   var Processor = require('@dermah/pulsar-input-keyboard');
-  var processor = new Processor(io, config);
+  var processor = new Processor(config);
+
+  processor.on('pulse', pulse => {
+    io.emit('pulse', pulse)
+  });
+  processor.on('pulsar control', pulse => {
+    io.emit('pulsar control', pulse)
+  });
+  processor.on('pulse update', pulse => {
+    io.emit('pulse update', pulse);
+  });
 }
 
 module.exports = Transmitter;


### PR DESCRIPTION
Bump `pulsar-input-keyboard`, thus subscribing to the event emission model that pulsar is starting to follow. This makes the module not the transmitter it wants to be. It is becoming the event dispatcher but still serves the static files for rendering pulses (this is not good).
